### PR TITLE
#3 added docker-compose file for mssql and mysql and adapted appsetti…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,15 @@ Synchronization done.
 
 Yes it's blazing fast !
 
+## Build from source and run the tests
+- To build this repository, just run `dotnet build`
+
+- then start up the MSSQL and MySQL databases required for the integration tests using `docker-compose up` (or `docker-compose up -d` in case you want it to run in the background)
+
+- finally run `dotnet test -v n` where `-v n` means "verbosity n[ormal]". Otherwise it would be m[inimal] and the console won't show any output
+
+It won't get any easyer ;-)
+
 ## Need Help
 
 * Check the full documentation, available here : [https://dotmimsync.readthedocs.io/](https://dotmimsync.readthedocs.io/)

--- a/Tests/Dotmim.Sync.Tests/appsettings.json
+++ b/Tests/Dotmim.Sync.Tests/appsettings.json
@@ -1,8 +1,8 @@
 {
   "ConnectionStrings": {
-    "SqlConnection": "Data Source=(localdb)\\mssqllocaldb; Initial Catalog={0}; Integrated Security=true;",
+    "SqlConnection": "Data Source=127.0.0.1,1444; Initial Catalog={0};User Id=SA;Password=Secr3T!!!",
     "AzureSqlConnection": "Data Source=YOUR_SERVER.database.windows.net; Initial Catalog={0}; Integrated Security=false;",
-    "MySqlConnection": "Server=127.0.0.1;Port=3307;Database={0};"
+    "MySqlConnection": "Server=127.0.0.1;Port=3306;Database={0};Uid=root;Pwd=secret;"
   },
 
   "AllowedHosts": "*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.7"
+
+services: 
+    # copied from https://hub.docker.com/_/mysql/?tab=description
+    mysql:
+        image: mysql:8.0.21
+        command: --default-authentication-plugin=mysql_native_password
+        restart: always
+        environment:
+            #MYSQL_ALLOW_EMPTY_PASSWORD: 1
+            MYSQL_ROOT_PASSWORD: secret
+        ports:
+            - 3306:3306
+        # note: uncomment volume ONLY if you want to keep databases and password settings
+        #volumes:
+        #    - dotmim-mysql-data:/var/lib/mysql
+    adminer:
+        image: adminer
+        restart: always
+        ports:
+            - 8080:8080
+    mssql:
+        # see: https://docs.docker.com/compose/aspnet-mssql-compose/
+        image: "mcr.microsoft.com/mssql/server"
+        environment:
+            ACCEPT_EULA: Y
+            SA_PASSWORD: Secr3T!!!
+        ports:
+            - 1444:1433
+
+#volumes:
+#    dotmim-mysql-data:
+    


### PR DESCRIPTION
…ngs.json

## Build from source and run the tests
- To build this repository, just run `dotnet build`

- then start up the MSSQL and MySQL databases required for the integration tests using `docker-compose up` (or `docker-compose up -d` in case you want it to run in the background)

- finally run `dotnet test -v n` where `-v n` means "verbosity n[ormal]". Otherwise it would be m[inimal] and the console won't show any output

It won't get any easyer ;-)